### PR TITLE
Register object and VS2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ build/bin/windows/Torque6*
 build/vs2010/
 build/vs2012/
 build/vs2013/
+build/vs2015/
 build/gmake/
 projects/00-Console/cache/
 projects/01-AnimatedMesh/cache/

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ Torque2D_DEBUG.exe
 Torque2DGame.app
 Torque2DGame_Debug.app
 linkmap.txt
-    
+
 # Compiled source #
 ###################
 engine/Link/
@@ -71,7 +71,7 @@ engine/compilers/android/obj/
 *.bin
 
 # BUILD FILES
-build/bin/windows/Torque6*
+build/bin/windows*/Torque6*
 build/vs2010/
 build/vs2012/
 build/vs2013/

--- a/src/game/defaultGame.cc
+++ b/src/game/defaultGame.cc
@@ -242,6 +242,7 @@ void initializeGameNetworking()
 	NetConnection *client = new GameConnection();
 	client->assignName("ServerConnection");
 	NetConnection::setServerConnection(client);
+   client->registerObject();
 
 	NetConnection *server = new GameConnection();
 	const char *error = NULL;


### PR DESCRIPTION
A few fixes for working with Torque6 in VS2015 and added client->registerObject to void initializeGameNetworking()
